### PR TITLE
fix: Bind error handlers properly

### DIFF
--- a/lib/__tests__/index.test.ts
+++ b/lib/__tests__/index.test.ts
@@ -3,7 +3,9 @@ import chance from 'chance';
 import { postEvent } from '../http';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../http');
+vi.mock('../http', () => ({
+  postEvent: vi.fn(),
+}));
 const postEventMock = vi.mocked(postEvent);
 
 const addEventListenerSpy = vi.spyOn(self, 'addEventListener');


### PR DESCRIPTION
There were issues accessing private functions because `addEventListener('error', this.#onError);` didn't bind the `#onError` method to the client instance properly.